### PR TITLE
fix(#10): change naming convensions for tests. now it follows a structure.

### DIFF
--- a/pkg/core/in_mem_get_test.go
+++ b/pkg/core/in_mem_get_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInMemoryCommandRepository_Get(t *testing.T) {
+func TestInMemoryCommandRepository_Get_ExistingInteger(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a new in-memory repository instance
@@ -16,7 +16,6 @@ func TestInMemoryCommandRepository_Get(t *testing.T) {
 		store: make(map[string]types.ColumnValue),
 	}
 
-	// Test case 1: Retrieve a value that exists (integer type)
 	key1 := "intKey"
 	value1 := "123"
 	imc.Set(ctx, key1, value1)
@@ -24,28 +23,52 @@ func TestInMemoryCommandRepository_Get(t *testing.T) {
 	result, err := imc.Get(ctx, key1)
 	assert.NoError(t, err, "Get should not return an error for existing key")
 	assert.Equal(t, "123", result, "The returned value should match the stored value as a string")
+}
 
-	// Test case 2: Retrieve a value that exists (float type)
+func TestInMemoryCommandRepository_Get_ExistingFloat(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a new in-memory repository instance
+	imc := &InMemoryCommandRepository{
+		store: make(map[string]types.ColumnValue),
+	}
+
 	key2 := "floatKey"
 	value2 := "123.45"
 	imc.Set(ctx, key2, value2)
 
-	result, err = imc.Get(ctx, key2)
+	result, err := imc.Get(ctx, key2)
 	assert.NoError(t, err, "Get should not return an error for existing key")
 	assert.Equal(t, "123.45", result, "The returned value should match the stored value as a string")
+}
 
-	// Test case 3: Retrieve a value that exists (string type)
+func TestInMemoryCommandRepository_Get_ExistingString(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a new in-memory repository instance
+	imc := &InMemoryCommandRepository{
+		store: make(map[string]types.ColumnValue),
+	}
+
 	key3 := "stringKey"
 	value3 := "hello"
 	imc.Set(ctx, key3, value3)
 
-	result, err = imc.Get(ctx, key3)
+	result, err := imc.Get(ctx, key3)
 	assert.NoError(t, err, "Get should not return an error for existing key")
 	assert.Equal(t, "hello", result, "The returned value should match the stored value as a string")
+}
 
-	// Test case 4: Attempt to retrieve a value for a key that does not exist
+func TestInMemoryCommandRepository_Get_NonExistantValue_ErrNotFound(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a new in-memory repository instance
+	imc := &InMemoryCommandRepository{
+		store: make(map[string]types.ColumnValue),
+	}
+
 	missingKey := "missingKey"
-	result, err = imc.Get(ctx, missingKey)
+	result, err := imc.Get(ctx, missingKey)
 	assert.Error(t, err, "Get should return an error for a non-existing key")
 	assert.Equal(t, ErrNotFound, err, "The error should be ErrNotFound")
 	assert.Equal(t, "", result, "The returned value should be an empty string when the key is not found")

--- a/pkg/core/in_mem_set_test.go
+++ b/pkg/core/in_mem_set_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInMemoryCommandRepository_Set(t *testing.T) {
+func TestInMemoryCommandRepository_Set_Integer(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a new in-memory repository instance
@@ -16,7 +16,7 @@ func TestInMemoryCommandRepository_Set(t *testing.T) {
 		store: make(map[string]types.ColumnValue),
 	}
 
-	// Test case 1: Adding a new key with an integer value
+	// Adding a new key with an integer value
 	key1 := "intKey"
 	value1 := "123"
 
@@ -28,12 +28,21 @@ func TestInMemoryCommandRepository_Set(t *testing.T) {
 	assert.True(t, exists, "The key should exist in the store")
 	assert.Equal(t, types.IntType, storedValue1.Type(), "The stored value should be of IntType")
 	assert.Equal(t, 123, storedValue1.Value(), "The stored value should match the input value as an integer")
+}
 
-	// Test case 2: Adding a new key with a float value
+func TestInMemoryCommandRepository_Set_Float(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a new in-memory repository instance
+	imc := &InMemoryCommandRepository{
+		store: make(map[string]types.ColumnValue),
+	}
+
+	// Adding a new key with a float value
 	key2 := "floatKey"
 	value2 := "123.45"
 
-	err = imc.Set(ctx, key2, value2)
+	err := imc.Set(ctx, key2, value2)
 	assert.NoError(t, err, "Set should not return an error")
 
 	// Check if the key-value pair was correctly stored and its type is float
@@ -42,11 +51,21 @@ func TestInMemoryCommandRepository_Set(t *testing.T) {
 	assert.Equal(t, types.FloatType, storedValue2.Type(), "The stored value should be of FloatType")
 	assert.Equal(t, 123.45, storedValue2.Value(), "The stored value should match the input value as a float")
 
-	// Test case 3: Adding a new key with a string value
+}
+
+func TestInMemoryCommandRepository_Set_String(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a new in-memory repository instance
+	imc := &InMemoryCommandRepository{
+		store: make(map[string]types.ColumnValue),
+	}
+
+	// Adding a new key with a string value
 	key3 := "stringKey"
 	value3 := "hello"
 
-	err = imc.Set(ctx, key3, value3)
+	err := imc.Set(ctx, key3, value3)
 	assert.NoError(t, err, "Set should not return an error")
 
 	// Check if the key-value pair was correctly stored and its type is string
@@ -54,9 +73,24 @@ func TestInMemoryCommandRepository_Set(t *testing.T) {
 	assert.True(t, exists, "The key should exist in the store")
 	assert.Equal(t, types.StringType, storedValue3.Type(), "The stored value should be of StringType")
 	assert.Equal(t, "hello", storedValue3.Value(), "The stored value should match the input value as a string")
+}
 
-	// Test case 4: Updating an existing key with a new value
+func TestInMemoryCommandRepository_Set_ExistingValue(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a new in-memory repository instance
+	imc := &InMemoryCommandRepository{
+		store: make(map[string]types.ColumnValue),
+	}
+
+	// Updating an existing key with a new value
 	newValue := "456"
+
+	key1 := "intKey"
+	value1 := "123"
+
+	err := imc.Set(ctx, key1, value1)
+	assert.NoError(t, err, "Set should not return an error")
 
 	err = imc.Set(ctx, key1, newValue)
 	assert.NoError(t, err, "Set should not return an error")


### PR DESCRIPTION
The structure is not yet documented but it looks something like this:
`InterfaceImplementationName_CommandName_InputName[_ExpectedErrorIfAny]`